### PR TITLE
proguard rule fixed for [java.lang.ExceptionInInitializerError]

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ excelToSQLite.importFromFile(directory_path, new ExcelToSQLite.ImportListener() 
 ```
 ## Proguard for SQLite2XL
 ```
--dontwarn org.apache.poi.**
+-keep public class org.apache.poi.** {*;}
 ```
 
 ## Using SQLite2XL


### PR DESCRIPTION
with `-dontwarn org.apache.poi.**` this rule, you may get below error but I have fixed.

```
java.lang.ExceptionInInitializerError
        at c.a.b.d.b.gb.a(:489)
```